### PR TITLE
Add Buffer functions and fix misleading comments

### DIFF
--- a/src/wgpu.zig
+++ b/src/wgpu.zig
@@ -1357,6 +1357,21 @@ pub const Buffer = *opaque {
     }
     extern fn wgpuBufferGetMappedRange(buffer: Buffer, offset: usize, size: usize) ?*anyopaque;
 
+    pub fn getMapState(buffer: Buffer) BufferMapState {
+        return wgpuBufferGetMapState(buffer);
+    }
+    extern fn wgpuBufferGetMapState(buffer: Buffer) BufferMapState;
+
+    pub fn getSize(buffer: Buffer) usize {
+        return @intCast(wgpuBufferGetSize(buffer));
+    }
+    extern fn wgpuBufferGetSize(buffer: Buffer) u64;
+
+    pub fn getUsage(buffer: Buffer) BufferUsage {
+        return wgpuBufferGetUsage(buffer);
+    }
+    extern fn wgpuBufferGetUsage(buffer: Buffer) BufferUsage;
+
     // `offset` has to be a multiple of 8 (Dawn's validation layer will warn).
     // `size` has to be a multiple of 4 (Dawn's validation layer will warn).
     // `size == 0` will map entire range (from 'offset' to the end of the buffer).

--- a/src/wgpu.zig
+++ b/src/wgpu.zig
@@ -1347,8 +1347,8 @@ pub const Buffer = *opaque {
     }
     extern fn wgpuBufferGetConstMappedRange(buffer: Buffer, offset: usize, size: usize) ?*const anyopaque;
 
-    // `offset` has to be a multiple of 8 (otherwise `null` will be returned).
-    // `@sizeOf(T) * len` has to be a multiple of 4 (otherwise `null` will be returned).
+    // `offset` - in bytes, has to be a multiple of 8 (otherwise `null` will be returned).
+    // `len` - length of slice to return, in elements of type T, `@sizeOf(T) * len` has to be a multiple of 4 (otherwise `null` will be returned).
     pub fn getMappedRange(buffer: Buffer, comptime T: type, offset: usize, len: usize) ?[]T {
         if (len == 0) return null;
         const ptr = wgpuBufferGetMappedRange(buffer, offset, @sizeOf(T) * len);
@@ -1372,9 +1372,8 @@ pub const Buffer = *opaque {
     }
     extern fn wgpuBufferGetUsage(buffer: Buffer) BufferUsage;
 
-    // `offset` has to be a multiple of 8 (Dawn's validation layer will warn).
-    // `size` has to be a multiple of 4 (Dawn's validation layer will warn).
-    // `size == 0` will map entire range (from 'offset' to the end of the buffer).
+    // `offset` - in bytes, has to be a multiple of 8 (Dawn's validation layer will warn).
+    // `size` - size of buffer to map in bytes, has to be a multiple of 4 (Dawn's validation layer will warn).
     pub fn mapAsync(
         buffer: Buffer,
         mode: MapMode,


### PR DESCRIPTION
Hi, I've implemented several more functions in the zig Buffer interface, and modified a couple of comments that were confusing or incorrect.

Particularly, in mapAsync, size==0 will not map the entire buffer per the webgpu spec. If you call mapAsync with size=0, get[Const]MappedRange will always return null because any size to get will always be larger than the mapped range.

Source:
https://www.w3.org/TR/webgpu/#dom-gpubuffer-mapasync