### PR TITLE
Add `allow_unsafe_apis` toggle to Dawn as a dependency flag

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,7 @@ const log = std.log.scoped(.zgpu);
 const default_options = struct {
     const uniforms_buffer_size = 4 * 1024 * 1024;
     const dawn_skip_validation = false;
+    const dawn_allow_unsafe_apis = false;
     const buffer_pool_size = 256;
     const texture_pool_size = 256;
     const texture_view_pool_size = 256;
@@ -32,6 +33,11 @@ pub fn build(b: *std.Build) void {
             "dawn_skip_validation",
             "Disable Dawn validation",
         ) orelse default_options.dawn_skip_validation,
+        .dawn_allow_unsafe_apis = b.option(
+            bool,
+            "dawn_allow_unsafe_apis",
+            "Allow unsafe WebGPU APIs (e.g. timestamp queries)",
+        ) orelse default_options.dawn_allow_unsafe_apis,
         .buffer_pool_size = b.option(
             u32,
             "buffer_pool_size",

--- a/src/zgpu.zig
+++ b/src/zgpu.zig
@@ -205,20 +205,26 @@ pub const GraphicsContext = struct {
                 }
             }).callback;
 
-            const toggles = [_][*:0]const u8{"skip_validation"};
+            var toggles: [2][*:0]const u8 = undefined;
+            var num_toggles: usize = 0;
+            if (zgpu_options.dawn_skip_validation) {
+                toggles[num_toggles] = "skip_validation";
+                num_toggles += 1;
+            }
+            if (zgpu_options.dawn_allow_unsafe_apis) {
+                toggles[num_toggles] = "allow_unsafe_apis";
+                num_toggles += 1;
+            }
             const dawn_toggles = wgpu.DawnTogglesDescriptor{
                 .chain = .{ .next = null, .struct_type = .dawn_toggles_descriptor },
-                .enabled_toggles_count = toggles.len,
+                .enabled_toggles_count = num_toggles,
                 .enabled_toggles = &toggles,
             };
 
             var response = Response{};
             adapter.requestDevice(
                 wgpu.DeviceDescriptor{
-                    .next_in_chain = if (zgpu_options.dawn_skip_validation)
-                        @ptrCast(&dawn_toggles)
-                    else
-                        null,
+                    .next_in_chain = @ptrCast(&dawn_toggles),
                     .required_features_count = options.required_features.len,
                     .required_features = options.required_features.ptr,
                     .required_limits = @ptrCast(options.required_limits),


### PR DESCRIPTION
WebGPU features like Timestamp Queries are disabled by default via the validation layers as they are considered unsafe for web use. So to use these features we need to explicitly allow them. Once enabled, a GraphicsContext can be successfully created with the "timestamp_query" and "timestamp_query_inside_passes" features, instead of having to disable all validation to create timestamp `QuerySet`s.